### PR TITLE
Pull libsodium from git.

### DIFF
--- a/.travis/linux-install
+++ b/.travis/linux-install
@@ -7,6 +7,7 @@ cabal update
 
 # Install libsodium into $HOME/.cabal/extra-dist.
 tools/install-libsodium
+cabal install happy
 cabal install --only-dependencies $EXTRA_DIRS
 cabal install codecov-haskell hpc-coveralls aeson-0.9.0.1 stylish-haskell hlint
 # cabal install pandoc

--- a/tools/install-libsodium
+++ b/tools/install-libsodium
@@ -7,17 +7,20 @@ mkdir -p $HOME/.cabal/extra-dist
 if test -f $HOME/.cabal/extra-dist/lib/libsodium.a; then exit; fi
 if pkg-config libsodium; then exit; fi
 
-cd test/toxcore/libsodium
+git clone --depth=1 https://github.com/jedisct1/libsodium ../libsodium
+cd ../libsodium
 
 git rev-parse HEAD > new-hash
 if diff new-hash $HOME/.cabal/extra-dist/libsodium.hash; then
+  echo "libsodium is up-to-date"
   rm new-hash
-  exit
+else
+  echo "Hashes differ => rebuilding"
+  sh autogen.sh
+  ./configure --prefix=$HOME/.cabal/extra-dist
+  make install
+
+  mv new-hash $HOME/.cabal/extra-dist/libsodium.hash
 fi
 
-echo "Hashes differ => rebuilding"
-sh autogen.sh
-./configure --prefix=$HOME/.cabal/extra-dist
-make install
-
-mv new-hash $HOME/.cabal/extra-dist/libsodium.hash
+cd -


### PR DESCRIPTION
It is no longer a submodule, so we can't build it from within our tree.