### PR TITLE
Add reference implementation for tests.

### DIFF
--- a/hstox.cabal
+++ b/hstox.cabal
@@ -110,6 +110,20 @@ library
     exposed-modules:
         ToxTestSuite
 
+executable tox-refsut
+  default-language: Haskell2010
+  hs-source-dirs:
+      src
+  ghc-options:
+      -Wall
+      -fno-warn-unused-imports
+  build-depends:
+      base < 5
+    , hstox
+  main-is: tox-refsut.hs
+  if flag(library-only)
+    buildable: False
+
 executable tox-spectest
   default-language: Haskell2010
   hs-source-dirs:

--- a/src/tox-refsut.hs
+++ b/src/tox-refsut.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import           Network.Tox.Testing (serve)
+
+
+main :: IO ()
+main = serve


### PR DESCRIPTION
Can be used to run manual tests against:
```sh
$ tox-refsut &
$ echo 'ObjectArray
    [ ObjectInt 0
    , ObjectInt 0
    , ObjectStr "Binary.decode"
    , ObjectArray
      [ ObjectStr "PlainText"
      , ObjectBin "\128\0\0\0\0\0\0\0"
      ]
    ]' \
    | msgpack-parser \
    | nc localhost 1234 \
    | msgpack-parser
```

The second `msgpack-parser` call decodes the msgpack-rpc response from
the SUT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/94)
<!-- Reviewable:end -->
