### PR TITLE
Clarified and fixed save format of friends.

### DIFF
--- a/src/tox/Network/Tox.lhs
+++ b/src/tox/Network/Tox.lhs
@@ -3459,23 +3459,18 @@ Friend:
 Some of the integers in this structure are stored in Big Endian. This is
 denoted with "(BE)".
 
-Unfortunately, toxcore copies the friend structure directly from memory to the
-state file. This makes the state format platform dependent because the way a
-structure is laid out in memory differs across platforms and compilers. A
-common layout of this structure in memory (GCC on x86 and x86\_64) is described
-below and should be accounted for both when serializing and deserializing the
-state file.
-
 \begin{tabular}{l|l}
   Length        & Contents \\
   \hline
   \texttt{1}    & \texttt{uint8_t} Status \\
   \texttt{32}   & Long term public key \\
-  \texttt{1024} & Friend request message as a UTF-8 encoded string \\
+  \texttt{1024} & Friend request message as a byte string \\
+  \texttt{1}    & PADDING \\
   \texttt{2}    & \texttt{uint16_t} Size of the friend request message (BE) \\
-  \texttt{128}  & Name as a UTF-8 encoded string \\
+  \texttt{128}  & Name as a byte string \\
   \texttt{2}    & \texttt{uint16_t} Size of the name (BE) \\
-  \texttt{1007} & Status message as a UTF-8 encoded string \\
+  \texttt{1007} & Status message as a byte string \\
+  \texttt{1}    & PADDING \\
   \texttt{2}    & \texttt{uint16_t} Size of the status message (BE) \\
   \texttt{1}    & \texttt{uint8_t} User status (see also: \texttt{USERSTATUS}) \\
   \texttt{3}    & PADDING \\


### PR DESCRIPTION
The PR fixing the save format: [#281](https://github.com/TokTok/c-toxcore/pull/281)
Friend request message, name, and status messages have always been byte strings with UTF-8 being a common but not enforced encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/95)
<!-- Reviewable:end -->
