### PR TITLE
Fix ordering bugs in KBuckets

### DIFF
--- a/src/testsuite/Network/Tox/DHT/KBucketsSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/KBucketsSpec.hs
@@ -114,7 +114,7 @@ spec = do
       in
       map (KBuckets.bucketIndex zeroKey) inputs `shouldBe` outputs
     
-  describe "addNode" $ do
+  describe "addNode" $
     it "keeps the smallest k entries in the bucket indexed by the index of the added node" $
       property $ \kBuckets nodeInfo -> KBuckets.baseKey kBuckets /= NodeInfo.publicKey nodeInfo ==>
         let
@@ -128,7 +128,7 @@ spec = do
         in
           take (KBuckets.bucketSize kBuckets) (sort allEntries) `shouldBe` sort keptEntries
 
-  describe "foldNodes" $ do
+  describe "foldNodes" $
     it "iterates over nodes in order of distance from the base key" $
       property $ \kBuckets ->
         let


### PR DESCRIPTION
Tests for KBuckets.addNode and KBuckets.foldNodes, which fail with current
master, and fixes to make them pass. The original code seemed to wrongly assume
that maps are ordered by their values rather than by their keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/120)
<!-- Reviewable:end -->
