### PR TITLE
Mark Network.Tox.DHT.Operation as Trustworthy instead of Safe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 - chmod +x $HOME/.cabal/bin/stylish-haskell-lhs
 - hlint .
 - stylish-haskell-lhs -i .
-- git diff
+- git diff --exit-code
 - rm -f $HOME/.cabal && ln -s $HOME/.cabal-build $HOME/.cabal
 - rm -f $HOME/.ghc && ln -s $HOME/.ghc-build $HOME/.ghc
 - cabal install --enable-tests --enable-benchmarks --only-dependencies ./ semdoc

--- a/src/tox/Network/Tox/DHT/Operation.lhs
+++ b/src/tox/Network/Tox/DHT/Operation.lhs
@@ -4,8 +4,8 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE Safe                  #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE Trustworthy           #-}
 module Network.Tox.DHT.Operation where
 
 import           Control.Applicative           (Applicative, pure, (*>), (<$>),


### PR DESCRIPTION
Older Control.Monad.Random versions are not Safe Haskell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/124)
<!-- Reviewable:end -->
