### PR TITLE
Support an empty string as SUT in tox-spectest.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
 - choco install ghc
 - curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.11-mingw.tar.gz | tar zx
 - refreshenv
+- set PATH=%PATH%;C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.0.2\bin
 
 build_script:
 - cabal update


### PR DESCRIPTION
This avoids the process spawn so you can run your own sut and run tests
against it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/127)
<!-- Reviewable:end -->
