### PR TITLE
Increase delay for spectest from 100ms to 2 seconds.

### DIFF
--- a/src/tox-spectest.hs
+++ b/src/tox-spectest.hs
@@ -20,9 +20,13 @@ withSut "" action = action
 withSut sut action = do
   -- Start a SUT (System Under Test) process that will listen on port 1234.
   (_, _, _, sutProc) <- createProcess $ proc sut []
-  -- 100ms delay to give the SUT time to set up its socket before we try to
-  -- build connections in the test runner.
-  threadDelay $ 100 * 1000
+  -- 2 seconds delay to give the SUT time to set up its socket before we try
+  -- to build connections in the test runner. This is high, because on Travis,
+  -- the SUT can take quite some time to become ready to accept connections.
+  -- Ideally, we would probe the SUT every 100ms or so until it starts
+  -- accepting RPCs, but that's something we should consider putting into the
+  -- RPC library itself.
+  threadDelay $ 2 * 1000 * 1000
   action
   terminateProcess sutProc
 


### PR DESCRIPTION
This is likely way too much (1 second should be enough for anyone), but
adding another second makes it that much less likely to fail, saving
about 8 minutes every time it saves a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/128)
<!-- Reviewable:end -->
