### PR TITLE
Use new hspec_library rule to work around rules_haskell issue 625.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell_test")
+load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_library")
 load("//tools/project:build_defs.bzl", "project")
 
 project()
@@ -40,9 +41,8 @@ haskell_library(
     ],
 )
 
-haskell_library(
+hspec_library(
     name = "testsuite",
-    srcs = glob(["src/testsuite/**/*.*hs"]),
     compiler_flags = [
         "-j4",
         "-Wall",


### PR DESCRIPTION
See https://github.com/tweag/rules_haskell/issues/625

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/159)
<!-- Reviewable:end -->
