### PR TITLE
Update libsodium to 1.0.17 to fix Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ cache:
 
 install:
   - choco install ghc --version 8.2.2
-  - curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.16-mingw.tar.gz | tar zx
+  - curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-mingw.tar.gz | tar zx
   - refreshenv
 
 build_script:


### PR DESCRIPTION
The 1.0.16 mingw variant seems to have been deleted when the 1.0.17
release was made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/161)
<!-- Reviewable:end -->
