### PR TITLE
chore: Use toktok-stack 0.0.23 for cirrus builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,45 +1,13 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.19
+    image: toxchat/toktok-stack:0.0.23-third_party
     cpu: 2
     memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-toxcore
   test_all_script:
-    - bazel test -k
+    - cd /src/workspace && bazel test -k
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --config=release
         //hs-toxcore/...
-
-android-aarch64_task:
-  container:
-    image: toktoknet/ghc-android:8.10.7.aarch64
-    cpu: 2
-    memory: 6G
-  build_script:
-    - android/build.sh
-
-android-arm_task:
-  container:
-    image: toktoknet/ghc-android:8.10.7.arm
-    cpu: 2
-    memory: 6G
-  build_script:
-    - android/build.sh
-
-android-i686_task:
-  container:
-    image: toktoknet/ghc-android:8.10.7.i686
-    cpu: 2
-    memory: 6G
-  build_script:
-    - android/build.sh
-
-android-x86_64_task:
-  container:
-    image: toktoknet/ghc-android:8.10.7.x86_64
-    cpu: 2
-    memory: 6G
-  build_script:
-    - android/build.sh


### PR DESCRIPTION
This version has pre-built third party binaries, speeding up the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-toxcore/190)
<!-- Reviewable:end -->
